### PR TITLE
QOL fixes, but mostly improved utils.resample_covar function

### DIFF
--- a/aoa/aoa.py
+++ b/aoa/aoa.py
@@ -1,5 +1,5 @@
 import numpy as np
-from utils import sinc_derivative
+from ..utils import sinc_derivative
 
 
 def make_gain_functions(type, d_lam, psi_0):

--- a/aoa/directional.py
+++ b/aoa/directional.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from utils.unit_conversions import db_to_lin
-from utils import constants
+from ..utils.unit_conversions import db_to_lin
+from ..utils import constants
 from .aoa import make_gain_functions
 
 

--- a/aoa/doppler.py
+++ b/aoa/doppler.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from utils.unit_conversions import db_to_lin
-from utils import constants
+from ..utils.unit_conversions import db_to_lin
+from ..utils import constants
 
 
 def crlb(snr, num_samples, amplitude, ts, f, radius, fr, psi):

--- a/aoa/interferometer.py
+++ b/aoa/interferometer.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-from utils.unit_conversions import lin_to_db, db_to_lin
+from ..utils.unit_conversions import lin_to_db, db_to_lin
 
 
 def crlb(snr1, snr2, num_samples, d_lam, psi_true):

--- a/aoa/watson_watt.py
+++ b/aoa/watson_watt.py
@@ -4,7 +4,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
-from utils.unit_conversions import db_to_lin
+from ..utils.unit_conversions import db_to_lin
 
 
 def crlb(snr, num_samples):

--- a/atm/model.py
+++ b/atm/model.py
@@ -1,6 +1,6 @@
-from atm import reference
+from . import reference
 import numpy as np
-from utils import geo
+from ..utils import geo
 
 
 def calc_atm_loss(freq_hz, gas_path_len_m=0, rain_path_len_m=0, cloud_path_len_m=0, atmosphere=None, pol_angle=0,
@@ -35,8 +35,7 @@ def calc_atm_loss(freq_hz, gas_path_len_m=0, rain_path_len_m=0, cloud_path_len_m
 
     # Compute loss coefficients
     if np.any(gas_path_len_m > 0):
-        coeff_ox, coeff_water = get_gas_loss_coeff(freq_hz, atmosphere.press, atmosphere.water_vapor_press,
-                                                   atmosphere.temp)
+        coeff_ox, coeff_water = get_gas_loss_coeff(freq_hz, atmosphere.press, atmosphere.water_vapor_press, atmosphere.temp)
         coeff_gas = coeff_ox + coeff_water
     else:
         coeff_gas = 0
@@ -330,14 +329,14 @@ def get_gas_loss_coeff(freq_hz, press, water_vapor_press, temp):
     # Compute complex refractivities
     # Now that we've summed over the spectral lines (or, are about to), strip the extra dimension from
     # fo and nd. This prevents errors with array broadcasting.
-    f0 = f0[..., 0]
-    nd = nd[..., 0]
-    refractivity_oxygen = np.sum(line_strength_oxygen*line_shape_oxygen, axis=-1) + nd
-    refractivity_water = np.sum(line_strength_water*line_shape_water, axis=-1)
+    f0 = np.squeeze(f0)
+    nd = np.squeeze(nd)
+    refractivity_oxygen = np.sum(np.multiply(line_strength_oxygen,line_shape_oxygen), axis=-1) + nd
+    refractivity_water = np.sum(np.multiply(line_strength_water,line_shape_water), axis=-1)
 
     # Compute coefficients
-    coeff_ox = .1820*f0*refractivity_oxygen
-    coeff_water = .1820*f0*refractivity_water
+    coeff_ox = .1820*np.multiply(f0,refractivity_oxygen)
+    coeff_water = .1820*np.multiply(f0,refractivity_water)
     
     # Handle all freqs < 1 GHz
     if np.any(f0 < 1):
@@ -353,5 +352,4 @@ def get_gas_loss_coeff(freq_hz, press, water_vapor_press, temp):
         else:
             _, mask_full = np.broadcast_arrays(coeff_water, low_freq_mask)
             np.place(coeff_water, mask_full, 0)
-
     return coeff_ox, coeff_water

--- a/detector/squareLaw.py
+++ b/detector/squareLaw.py
@@ -1,8 +1,8 @@
 import scipy.stats as stats
 import numpy as np
-from utils.unit_conversions import db_to_lin
+from ..utils.unit_conversions import db_to_lin
 import warnings
-import prop
+from .. import prop
 
 
 def det_test(z, noise_var, prob_fa):

--- a/detector/xcorr.py
+++ b/detector/xcorr.py
@@ -1,8 +1,8 @@
 import numpy as np
 import scipy.stats as stats
 from . import squareLaw
-from utils.unit_conversions import lin_to_db, db_to_lin
-import prop
+from ..utils.unit_conversions import lin_to_db, db_to_lin
+from .. import prop
 
 
 def det_test(y1, y2, noise_var, num_samples, prob_fa):

--- a/examples/chapter10.py
+++ b/examples/chapter10.py
@@ -2,8 +2,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import numpy.random
 
-import utils
-import triang
+from .. import utils
+from .. import triang
 import time
 
 

--- a/examples/chapter11.py
+++ b/examples/chapter11.py
@@ -1,8 +1,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-import utils
-import tdoa
+from .. import utils
+from .. import tdoa
 
 
 def run_all_examples():

--- a/examples/chapter12.py
+++ b/examples/chapter12.py
@@ -1,8 +1,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-import utils
-import fdoa
+from .. import utils
+from .. import fdoa
 
 
 def run_all_examples():

--- a/examples/chapter13.py
+++ b/examples/chapter13.py
@@ -4,8 +4,8 @@ import time
 
 import scipy.linalg
 
-import utils
-import hybrid
+from .. import utils
+from .. import hybrid
 
 
 def run_all_examples():

--- a/examples/chapter3.py
+++ b/examples/chapter3.py
@@ -1,11 +1,12 @@
 import numpy as np
 from scipy import stats
 import matplotlib.pyplot as plt
-import prop
-import detector
-import utils
-from utils.unit_conversions import lin_to_db, db_to_lin
-
+from .. import prop
+from .. import detector
+from .. import utils
+# from utils.unit_conversions import lin_to_db, db_to_lin
+lin_to_db = utils.unit_conversions.lin_to_db
+db_to_lin = utils.unit_conversions.db_to_lin
 
 def run_all_examples(rng=None, colors=None):
     """

--- a/examples/chapter4.py
+++ b/examples/chapter4.py
@@ -1,9 +1,9 @@
 import numpy as np
 import matplotlib.pyplot as plt
-import prop
-import detector
-import utils
-from utils.unit_conversions import lin_to_db
+from .. import prop
+from .. import detector
+from .. import utils
+from ..utils.unit_conversions import lin_to_db
 
 
 def run_all_examples(colors=None):

--- a/examples/chapter5.py
+++ b/examples/chapter5.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from utils.unit_conversions import db_to_lin
+from ..utils.unit_conversions import db_to_lin
 from scipy import stats
 
 

--- a/examples/chapter7.py
+++ b/examples/chapter7.py
@@ -1,9 +1,9 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from utils import constants
-from utils.unit_conversions import lin_to_db
-import prop
-import aoa
+from ..utils import constants
+from ..utils.unit_conversions import lin_to_db
+from .. import prop
+from .. import aoa
 
 
 def run_all_examples():

--- a/examples/chapter8.py
+++ b/examples/chapter8.py
@@ -1,10 +1,10 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from utils import constants
-from utils.unit_conversions import lin_to_db, db_to_lin
-from utils import print_elapsed
-import prop
-import array_df
+from ..utils import constants
+from ..utils.unit_conversions import lin_to_db, db_to_lin
+from ..utils import print_elapsed
+from .. import prop
+from .. import array_df
 from scipy import signal
 from scipy import io as sio
 import time
@@ -97,7 +97,7 @@ def generate_ex1_data(rng=None):
                                    + 1j * rng.standard_normal(size=(num_elements, num_samples)))
     noisy_signal = (rx_signal+noise)  # num_elements x num_samples
 
-    sio.savemat('examples/ex8_1.mat', {'x': noisy_signal,
+    sio.savemat('./ex8_1.mat', {'x': noisy_signal,
                                        'num_sources': num_sources,
                                        'num_elements': num_elements,
                                        'num_samples': num_samples,
@@ -122,7 +122,7 @@ def generate_ex1_data(rng=None):
     num_elements = 25   # Array elements
     num_samples = 100  # Time samples
     d_lam = .5
-    v = array_df.model.make_steering_vector(d_lam, num_elements)
+    v, v_dot = array_df.model.make_steering_vector(d_lam, num_elements)
 
     # Initialize source positions
     num_sources = 3  # Sources
@@ -141,15 +141,17 @@ def generate_ex1_data(rng=None):
 
     # Set up received data vector
     v_steer_mtx = v(psi)  # num_elements x num_sources
-    rx_signal = v_steer_mtx*np.sqrt(rx_pwr_w[:]/2)*(rng.standard_normal(size=(num_sources, num_samples))
-                                                    + 1j * (rng.standard_normal(size=(num_sources, num_samples))))
+    rx_signal = np.matmul( np.multiply(v_steer_mtx,np.sqrt(rx_pwr_w[:]/2)),
+                        (rng.standard_normal(size=(num_sources, num_samples))
+                        + 1j * (rng.standard_normal(size=(num_sources, num_samples))))
+        )
 
     # Add noise
     noise = np.sqrt(rx_noise_w/2)*(rng.standard_normal(size=(num_elements, num_samples))
                                    + 1j * rng.standard_normal(size=(num_elements, num_samples)))
     noisy_signal = (rx_signal+noise)  # num_elements x num_samples
 
-    sio.savemat('hw/problem8_5.mat', {'x': noisy_signal,
+    sio.savemat('./problem8_5.mat', {'x': noisy_signal,
                                       'num_sources': num_sources,
                                       'num_elements': num_elements,
                                       'num_samples': num_samples,
@@ -174,7 +176,7 @@ def generate_ex1_data(rng=None):
     num_elements = 25  # Array elements
     num_samples = 100  # Time samples
     d_lam = .5
-    v = array_df.model.make_steering_vector(d_lam, num_elements)
+    v, v_dot = array_df.model.make_steering_vector(d_lam, num_elements)
 
     # Initialize source positions
     num_sources = 3  # Sources
@@ -193,15 +195,17 @@ def generate_ex1_data(rng=None):
 
     # Set up received data vector
     v_steer_mtx = v(psi)  # num_elements x num_sources
-    rx_signal = v_steer_mtx*(np.sqrt(rx_pwr_w[:]/2)*(rng.standard_normal(size=(num_sources, num_samples))
-                                                     + 1j * (rng.standard_normal(size=(num_sources, num_samples)))))
+    rx_signal = np.matmul( np.multiply(v_steer_mtx,np.sqrt(rx_pwr_w[:]/2)),
+                        (rng.standard_normal(size=(num_sources, num_samples))
+                        + 1j * (rng.standard_normal(size=(num_sources, num_samples))))
+                )
 
     # Add noise
     noise = np.sqrt(rx_noise_w/2)*(rng.standard_normal(size=(num_elements, num_samples))
                                    + 1j * rng.standard_normal(size=(num_elements, num_samples)))
     noisy_signal = (rx_signal+noise)  # num_elements x num_samples
 
-    sio.savemat('hw/problem8_6.mat', {'x': noisy_signal,
+    sio.savemat('./problem8_6.mat', {'x': noisy_signal,
                                       'num_sources': num_sources,
                                       'num_elements': num_elements,
                                       'num_samples': num_samples,
@@ -222,7 +226,7 @@ def example1(rng=None):
     """
 
     # If the data is missing, make it
-    data_fnm = 'examples/ex8_1.mat'
+    data_fnm = './ex8_1.mat'
     if not os.path.exists(data_fnm):
         generate_ex1_data(rng)
 
@@ -305,7 +309,7 @@ def example2(rng=None):
     
     # Compute the number of snapshots
     t_samp = 1/(2*tx_freq)
-    num_samples = np.int(np.floor(t_integration/t_samp))
+    num_samples = int(np.floor(t_integration/t_samp))
     
     # Generate the array factor
     v, v_dot = array_df.model.make_steering_vector(d_lam, num_elements)

--- a/examples/chapter9.py
+++ b/examples/chapter9.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from utils import errors
+from ..utils import errors
 
 
 def run_all_examples():

--- a/fdoa/model.py
+++ b/fdoa/model.py
@@ -1,5 +1,5 @@
 import numpy as np
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 
 
@@ -142,7 +142,7 @@ def jacobian(x_sensor, x_source, v_sensor=None, v_source=None, ref_idx=None):
         out_dims = (n_dim, n_msmt)
 
     result = np.reshape(nabla_rn[:, test_idx_vec, :] - nabla_rn[:, ref_idx_vec, :], newshape=out_dims)
-
+    #result = np.delete(result, np.unique(ref_idx_vec), axis=1) # rm ref_sensor column b/c all zeros # not needed when parse_ref_sensors is fixed
     return result  # n_dim x nPair x n_source
 
 
@@ -183,6 +183,9 @@ def log_likelihood(x_sensor, rho_dot, cov, x_source, v_sensor=None, v_source=Non
     if do_resample:
         cov = utils.resample_covariance_matrix(cov, ref_idx)
 
+    if np.isscalar(cov):
+        # cov_lower = 1/cov
+        cov = np.array([[cov]])
     # Pre-invert the covariance matrix; to avoid repeatedly redoing the same work in the
     # for loop over source positions
     cov_inv = np.linalg.pinv(cov)
@@ -303,6 +306,7 @@ def draw_isodop(x1, v1, x2, v2, vdiff, num_pts, max_ortho):
         # Multiple velocity differences were specified, they have to be in ascending order to be used in contour command
         sort_idx = np.argsort(vdiff)
         unsort_idx = np.argsort(sort_idx)   # Indices to unsort
+        sort_idx = np.unravel_index(sort_idx, vdiff.shape)
         level_set = vdiff[sort_idx]
         multiple_outputs = True
     elif np.isscalar(vdiff):

--- a/fdoa/perf.py
+++ b/fdoa/perf.py
@@ -1,6 +1,6 @@
 import numpy as np
-import utils
-from utils.unit_conversions import db_to_lin
+from .. import utils
+from ..utils.unit_conversions import db_to_lin
 from . import model
 
 
@@ -56,8 +56,9 @@ def compute_crlb(x_sensor, v_sensor, x_source, cov, ref_idx=None, do_resample=Tr
                                        x_source=this_x, v_source=None,
                                        ref_idx=ref_idx)
 
-        # Squeeze the jacobian -- the third dimension is singleton, and doesn't matter here
-        this_jacobian = np.squeeze(this_jacobian)
+        # Squeeze the jacobian -- the third dimension is singleton, and doesn't matter here 
+        #LAZ: doesn't matter in matlab but matters in NP
+        # this_jacobian = np.squeeze(this_jacobian)
 
         # Compute the Fisher Information Matrix
         fisher_matrix = this_jacobian.dot(cov_inv.dot(np.conjugate(this_jacobian).T))

--- a/fdoa/solvers.py
+++ b/fdoa/solvers.py
@@ -1,5 +1,5 @@
-import utils
-from utils import solvers
+from .. import utils
+from ..utils import solvers
 from . import model
 import numpy as np
 

--- a/hybrid/model.py
+++ b/hybrid/model.py
@@ -1,8 +1,8 @@
 import numpy as np
-import triang
-import tdoa
-import fdoa
-import utils
+from .. import triang
+from .. import tdoa
+from .. import fdoa
+from ..import utils
 
 
 def measurement(x_source, x_aoa=None, x_tdoa=None, x_fdoa=None, v_fdoa=None, v_source=None, tdoa_ref_idx=None,

--- a/hybrid/perf.py
+++ b/hybrid/perf.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import utils
+from .. import utils
 from . import model
 
 
@@ -60,12 +60,11 @@ def compute_crlb(x_aoa, x_tdoa, x_fdoa, v_fdoa, x_source, cov, tdoa_ref_idx=None
                                            num_aoa_sensors + num_tdoa_sensors + test_idx_vec_fdoa), axis=0)
             ref_idx_vec = np.concatenate((ref_idx_vec_aoa, num_aoa_sensors + ref_idx_vec_tdoa,
                                           num_aoa_sensors + num_tdoa_sensors + ref_idx_vec_fdoa), axis=0)
-
             # Finally, we resample the full covariance matrix using the assembled indices
             cov = utils.resample_covariance_matrix(cov, test_idx_vec, ref_idx_vec)
 
         # Invert the covariance matrix
-        cov_inv = np.linalg.inv(cov)
+        cov_inv = np.linalg.pinv(cov)
 
     # Initialize output variable
     crlb = np.zeros((n_dim, n_dim, n_source))

--- a/hybrid/solvers.py
+++ b/hybrid/solvers.py
@@ -1,5 +1,5 @@
-import utils
-from utils import solvers
+from .. import utils
+from ..utils import solvers
 from . import model
 
 

--- a/make_figures/appendixB.py
+++ b/make_figures/appendixB.py
@@ -9,11 +9,11 @@ Nicholas O'Donoughue
 8 December 2022
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-import prop
+from .. import prop
 
 
 def make_all_figures(close_figs=False):

--- a/make_figures/appendixC.py
+++ b/make_figures/appendixC.py
@@ -9,11 +9,11 @@ Nicholas O'Donoughue
 8 December 2022
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-import atm
+from .. import atm
 
 
 def make_all_figures(close_figs=False):

--- a/make_figures/appendixD.py
+++ b/make_figures/appendixD.py
@@ -9,12 +9,12 @@ Nicholas O'Donoughue
 8 December 2022
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-import atm
-import noise
+from .. import atm
+from .. import noise
 
 
 def make_all_figures(close_figs=False):

--- a/make_figures/chapter1.py
+++ b/make_figures/chapter1.py
@@ -9,8 +9,8 @@ Nicholas O'Donoughue
 21 March 2021
 """
 
-import utils
-from utils.unit_conversions import lin_to_db, db_to_lin
+from .. import utils
+from ..utils.unit_conversions import lin_to_db, db_to_lin
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns

--- a/make_figures/chapter10.py
+++ b/make_figures/chapter10.py
@@ -9,12 +9,12 @@ Nicholas O'Donoughue
 19 May 2021
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-import triang
-from examples import chapter10
+from .. import triang
+from ..examples import chapter10
 
 
 def make_all_figures(close_figs=False, force_recalc=False):

--- a/make_figures/chapter11.py
+++ b/make_figures/chapter11.py
@@ -9,13 +9,13 @@ Nicholas O'Donoughue
 8 March 2022
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
 import seaborn as sns
-import tdoa
-from examples import chapter11
+from .. import tdoa
+from ..examples import chapter11
 
 
 def make_all_figures(close_figs=False, force_recalc=False):

--- a/make_figures/chapter12.py
+++ b/make_figures/chapter12.py
@@ -9,12 +9,12 @@ Nicholas O'Donoughue
 28 October 2022
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-import fdoa
-from examples import chapter12
+from .. import fdoa
+from ..examples import chapter12
 
 
 def make_all_figures(close_figs=False, force_recalc=False):

--- a/make_figures/chapter13.py
+++ b/make_figures/chapter13.py
@@ -9,16 +9,16 @@ Nicholas O'Donoughue
 4 December 2022
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy
 import seaborn as sns
-import triang
-import tdoa
-import fdoa
-import hybrid
-from examples import chapter13
+from .. import triang
+from .. import tdoa
+from .. import fdoa
+from .. import hybrid
+from ..examples import chapter13
 
 
 def make_all_figures(close_figs=False, force_recalc=False):

--- a/make_figures/chapter2.py
+++ b/make_figures/chapter2.py
@@ -10,14 +10,14 @@ Nicholas O'Donoughue
 22 March 2021
 """
 
-import utils
-from utils.unit_conversions import lin_to_db, db_to_lin
+from .. import utils
+from ..utils.unit_conversions import lin_to_db, db_to_lin
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy as sp
 from scipy.special import erf, erfinv
 import seaborn as sns
-
+from ..examples import chapter2
 
 def make_all_figures(close_figs=False):
     """
@@ -169,8 +169,9 @@ def make_figure_2(prefix=None, cmap=None):
     plt.fill_between(ell[mask], fa, label='False Alarm', facecolor=cmap(3), alpha=.6)
     
     # Add text overlay
-    plt.annotate(text='', xy=(eta-1.5, 0.325), xytext=(eta+1.5, 0.325), arrowprops=dict(arrowstyle='<->',
-                                                                                        color='k', lw=1))
+    plt.annotate(text='', xy=(eta-1.5, 0.325), xytext=(eta+1.5, 0.325), 
+        arrowprops=dict(arrowstyle='<->',
+            color='k', lw=1))
     plt.text(eta+.5, .35, 'Reduce $P_{FA}$')
     plt.text(eta-2.1, .35, 'Reduce $P_{MD}$')
     
@@ -205,7 +206,6 @@ def make_figure_3(prefix=None):
     :return: figure handle
     """
 
-    from examples import chapter2
     fig3 = chapter2.example2()
 
     # Draw the figure

--- a/make_figures/chapter3.py
+++ b/make_figures/chapter3.py
@@ -9,16 +9,16 @@ Nicholas O'Donoughue
 23 March 2021
 """
 
-import utils
-from utils.unit_conversions import lin_to_db, db_to_lin, kft_to_km
+from .. import utils
+from ..utils.unit_conversions import lin_to_db, db_to_lin, kft_to_km
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import stats
 import seaborn as sns
-import atm
-import prop
-import detector
-
+from .. import atm
+from .. import prop
+from .. import detector
+from ..examples import chapter3
 
 def make_all_figures(close_figs=False):
     """
@@ -390,7 +390,7 @@ def make_figure_9(prefix=None, rng=None, colors=None):
     :return: figure handle
     """
 
-    from examples import chapter3
+    
     fig9 = chapter3.example1(rng, colors)
 
     # Save figure
@@ -417,7 +417,6 @@ def make_figure_10(prefix=None, rng=None, colors=None):
     """
 
     # Figure 10, Monte Carlo Results
-    from examples import chapter3
     fig10 = chapter3.example2(rng, colors)
 
     # Save figure

--- a/make_figures/chapter4.py
+++ b/make_figures/chapter4.py
@@ -9,16 +9,16 @@ Nicholas O'Donoughue
 24 March 2021
 """
 
-import utils
-from utils.unit_conversions import lin_to_db, db_to_lin
+from .. import utils
+from ..utils.unit_conversions import lin_to_db, db_to_lin
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 import numpy as np
 from scipy.fft import fft, fftshift
 from scipy import stats
 import seaborn as sns
-import detector
-
+from .. import detector
+from ..examples import chapter4
 
 def make_all_figures(close_figs=False):
     """
@@ -181,8 +181,7 @@ def make_figure_1b(prefix=None, rng=None):
     plt.annotate(text='', xy=(-.5, 0), xytext=(-.5, -3), arrowprops=dict(arrowstyle='<->', color='k'))
     plt.annotate(text='', xy=(f0-bw/2, -3), xytext=(f0+bw/2, -3), arrowprops=dict(arrowstyle='<->', color='k'))
     plt.annotate(text=r'$B_s=1/T_{\mathrm{chip}}$', xy=(f0, -3), xytext=(.1, -6), arrowprops=dict(arrowstyle='-',
-                                                                                                  color='k'))
-
+        color='k'))
     # Turn off the axes
     ax = plt.gca()
     ax.axis('off')
@@ -580,7 +579,7 @@ def make_figure_7(prefix=None):
     :return: figure handle
     """
 
-    from examples import chapter4
+    
     fig7 = chapter4.example1()
 
     # Save figure
@@ -605,7 +604,6 @@ def make_figure_8(prefix=None, colors=None):
     :return: figure handle
     """
 
-    from examples import chapter4
     fig8 = chapter4.example2(colors)
 
     # Save figure

--- a/make_figures/chapter5.py
+++ b/make_figures/chapter5.py
@@ -9,10 +9,10 @@ Nicholas O'Donoughue
 25 March 2021
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import seaborn as sns
-from examples import chapter5
+from ..examples import chapter5
 
 
 def make_all_figures(close_figs=False):

--- a/make_figures/chapter6.py
+++ b/make_figures/chapter6.py
@@ -9,7 +9,7 @@ Nicholas O'Donoughue
 25 March 2021
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns

--- a/make_figures/chapter7.py
+++ b/make_figures/chapter7.py
@@ -9,13 +9,13 @@ Nicholas O'Donoughue
 26 March 2021
 """
 
-import utils
-from utils.unit_conversions import lin_to_db, db_to_lin
+from .. import utils
+from ..utils.unit_conversions import lin_to_db, db_to_lin
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-import aoa
-from examples import chapter7
+from .. import aoa
+from ..examples import chapter7
 
 
 def make_all_figures(close_figs=False, force_recalc=True):
@@ -299,8 +299,7 @@ def make_figure_5(prefix=None, rng=None, colors=None, force_recalc=True):
             rmse_psi[idx_num_samples, idx_snr] = np.sqrt(np.sum(np.absolute((psi_est-psi_true))**2)/this_num_mc)
 
             # CRLB
-            crlb_psi[idx_num_samples, idx_snr] = np.absolute(aoa.directional.crlb(snr_db, num_samples, g, g_dot,
-                                                                                  psi, psi_true))
+            crlb_psi[idx_num_samples, idx_snr] = np.absolute(aoa.directional.crlb(snr_db, num_samples, g, g_dot, psi, psi_true))
 
     # Generate figure
     fig5 = plt.figure()

--- a/make_figures/chapter8.py
+++ b/make_figures/chapter8.py
@@ -9,13 +9,13 @@ Nicholas O'Donoughue
 6 May 2021
 """
 
-import utils
-from utils.unit_conversions import lin_to_db, db_to_lin
+from .. import utils
+from ..utils.unit_conversions import lin_to_db, db_to_lin
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-import array_df
-from examples import chapter8
+from .. import array_df
+from ..examples import chapter8
 import time
 
 

--- a/make_figures/chapter9.py
+++ b/make_figures/chapter9.py
@@ -9,11 +9,11 @@ Nicholas O'Donoughue
 17 May 2021
 """
 
-import utils
+from .. import utils
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-from examples import chapter9
+from ..examples import chapter9
 
 
 def make_all_figures(close_figs=False):

--- a/noise/model.py
+++ b/noise/model.py
@@ -1,7 +1,7 @@
 import numpy as np
-from utils.unit_conversions import db_to_lin, lin_to_db
-from utils import constants
-import atm
+from ..utils.unit_conversions import db_to_lin, lin_to_db
+from ..utils import constants
+from .. import atm
 
 
 def get_thermal_noise(bandwidth_hz, noise_figure_db=0, temp_ext_k=0):

--- a/prop/model.py
+++ b/prop/model.py
@@ -1,6 +1,6 @@
 import numpy as np
-from utils import constants
-import atm
+from ..utils import constants
+from .. import atm
 
 
 def get_path_loss(range_m, freq_hz, tx_ht_m, rx_ht_m, include_atm_loss=True, atmosphere=None):

--- a/tdoa/model.py
+++ b/tdoa/model.py
@@ -1,7 +1,8 @@
 import numpy as np
-from utils import unit_conversions, geo
-import utils
-
+# from ..utils import unit_conversions, geo
+from .. import utils
+unit_conversions = utils.unit_conversions
+geo = utils.geo
 
 def measurement(x_sensor, x_source, ref_idx=None):
     """
@@ -25,6 +26,7 @@ def measurement(x_sensor, x_source, ref_idx=None):
     if n_dim1 != n_dim2:
         raise TypeError('First dimension of all inputs must match')
 
+
     # Parse sensor pairs
     test_idx_vec, ref_idx_vec = utils.parse_reference_sensor(ref_idx, n_sensor)
 
@@ -35,7 +37,6 @@ def measurement(x_sensor, x_source, ref_idx=None):
 
     # Compute range difference for each pair of sensors
     rdoa = r[test_idx_vec] - r[ref_idx_vec]
-
     return rdoa
 
 
@@ -85,7 +86,7 @@ def jacobian(x_sensor, x_source, ref_idx=None):
         out_dims = (n_dim, n_msmt)
 
     j = np.reshape(j, newshape=out_dims)
-
+    # j = np.delete(j, np.unique(ref_idx_vec), axis=1) # remove reference id b/c its all zeros # not needed when parse_ref_sensors is fixed
     return j
 
 
@@ -123,6 +124,9 @@ def log_likelihood(x_sensor, rho, cov, x_source, ref_idx=None, do_resample=False
     if do_resample:
         cov = utils.resample_covariance_matrix(cov, test_idx_vec, ref_idx_vec)
 
+    if np.isscalar(cov):
+        # cov_lower = 1/cov
+        cov = np.array([[cov]])
     # Pre-compute covariance matrix inverse
     cov_inv = np.linalg.inv(cov)
 

--- a/tdoa/perf.py
+++ b/tdoa/perf.py
@@ -1,5 +1,5 @@
 import numpy as np
-import utils
+from .. import utils
 from . import model
 
 
@@ -56,6 +56,6 @@ def compute_crlb(x_sensor, x_source, cov, ref_idx=None, do_resample=True):
             # inverted
             crlb[:, :, idx] = np.NaN
         else:
-            crlb[:, :, idx] = np.linalg.inv(fisher_matrix)
+            crlb[:, :, idx] = np.linalg.pinv(fisher_matrix)
 
     return crlb

--- a/tdoa/solvers.py
+++ b/tdoa/solvers.py
@@ -1,8 +1,8 @@
-import utils
-from utils import solvers
+from .. import utils
+# from ..utils import solvers
 from . import model
 import numpy as np
-
+solvers = utils.solvers
 
 def max_likelihood(x_sensor, rho, cov, x_ctr, search_size, epsilon=None, ref_idx=None, do_resample=False):
     """

--- a/triang/solvers.py
+++ b/triang/solvers.py
@@ -1,5 +1,5 @@
-import utils
-from utils import solvers
+from .. import utils
+from ..utils import solvers
 from . import model
 import numpy as np
 from itertools import combinations

--- a/utils/solvers.py
+++ b/utils/solvers.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy
 import matplotlib.pyplot as plt
 
-import utils
+# import utils
 
 
 def ls_solver(zeta, jacobian, covariance, x_init, epsilon=1e-6, max_num_iterations=10e3, force_full_calc=False,


### PR DESCRIPTION
On my M1 Apple silicon laptop (Numpy compiled with Apple vecLIB) and the line_profiler package, computing the CRLB for a 20x20 element TDOA sensor takes about 1.06 seconds, with 99% of the time being spent on the utils.resample_covariance_matrix() function. Using numpy's np.fromfunction() method to derive this array yields the same results and the same CRLB calculation now takes 0.006 seconds. This pull requests primarily improves this utils func. 

Made some QOL fixes on library's relative imports. Now we can import the entire folder (emitter_detection_python) and do stuff with it: 
```python
from emitter_detection_python import tdoa, fdoa, aoa, triang
triang.model.measurement(x_aoa
```
This is much nicer than `import os` and adding subfolder paths manually to every type of sensor. 

I also verified that make_figures works for Chapter 1-7, but I didn't have time to finish all the things.
