### PR TITLE
Fixed utils resampling. Also fixed hybrid because it didnt work with …

### DIFF
--- a/hybrid/model.py
+++ b/hybrid/model.py
@@ -26,13 +26,21 @@ def measurement(x_source, x_aoa=None, x_tdoa=None, x_fdoa=None, v_fdoa=None, v_s
     """
 
     # Construct component measurements
-    z_a = triang.model.measurement(x_sensor=x_aoa, x_source=x_source)
-    z_t = tdoa.model.measurement(x_sensor=x_tdoa, x_source=x_source, ref_idx=tdoa_ref_idx)
-    z_f = fdoa.model.measurement(x_sensor=x_fdoa, v_sensor=v_fdoa, x_source=x_source, v_source=v_source,
-                                 ref_idx=fdoa_ref_idx)
+    to_concat = []
+    if x_aoa is not None:
+        z_a = triang.model.measurement(x_sensor=x_aoa, x_source=x_source)
+        to_concat.append(z_a)
+    if x_tdoa is not None:
+        z_t = tdoa.model.measurement(x_sensor=x_tdoa, x_source=x_source, ref_idx=tdoa_ref_idx)
+        to_concat.append(z_t)
+    if x_fdoa is not None:
+        z_f = fdoa.model.measurement(x_sensor=x_fdoa, v_sensor=v_fdoa, 
+            x_source=x_source, v_source=v_source,
+            ref_idx=fdoa_ref_idx)
+        to_concat.append(z_f)
 
     # Combine into a single data vector
-    z = np.concatenate((z_a, z_t, z_f), axis=0)
+    z = np.concatenate(to_concat, axis=0)
 
     return z
 


### PR DESCRIPTION
Fixed a few things.

- Hybrid model and perf files didn't play nice with 0 inputs (e.g. `utils.safe_2d_shape(0)`  returns [1,1]). Fixed with if statements checking if num_aoa, num_tdoa, num_fdoa > 0
- Performed some exhaustive testing on improving the utils.resample_covariance_matrix. 
    - Line-profiler says about 50-100x speedup
    - Tested and verified against the following test cases (num_aoa, num_tdoa, num_fdoa): `(3,1,1), (3,4,1), (3,1,6), (3,4,6), (0,4,4), (10,20,15), (3,0,2), (1,2,0), (0,0,2),(0,2,0),(1,0,0)` 